### PR TITLE
correct extraction of uniprot or NCBI ID

### DIFF
--- a/scop3D.v3/Scop3dWorker/worker.py
+++ b/scop3D.v3/Scop3dWorker/worker.py
@@ -81,7 +81,10 @@ def downloadUniprotSequences(uniprotID, blastFile, sequencesFile, cutoff, verbos
 			for hsp in alignment.hsps:
 				title = alignment.title
 				words = title.split('|')
-				seqID = words[3]
+				if words[0] == 'gi':
+			            seqID = words[3]
+				elif words[0] == 'sp':
+				    seqID = words[1]
 				identityPercent = 100.0 * float(hsp.identities) / float(hsp.align_length)
 				if (identityPercent >= float(cutoff)):
 					try:


### PR DESCRIPTION
uniprot and ncbi header format no longer the same since gi notation has been suppressed from header in uniprot

could you please correct this on the production system?

thanks! 